### PR TITLE
Live log filter fix

### DIFF
--- a/public/app/livelog/livelog-filter-view.js
+++ b/public/app/livelog/livelog-filter-view.js
@@ -50,6 +50,7 @@ function($, _, Backbone, Marionette, app) {
 
 		initialize: function() {
 			this.on("itemview:filterToggle", this.filterToggle, this);
+			this.render();
 		},
 
 		filterToggle: function() {


### PR DESCRIPTION
Fixes the bug where the filter options for the live log are not shown. The problem was with Backbone/Marionette which did not render the list of user agents to filter by. Adds a call to render in the Marionette collection view.
