### PR TITLE
Enable usage of both old google auth and oauth2

### DIFF
--- a/app/auth/auth-google-oauth2.js
+++ b/app/auth/auth-google-oauth2.js
@@ -29,11 +29,11 @@ module.exports = function(app, passport, config) {
 	}
 
 	if(!clientSecret){
-		throw new Error('Missing clientSecret in google auth config');	
+		throw new Error('Missing clientSecret in google auth config');
 	}
 
 	if(!callbackURL){
-		throw new Error('Missing callbackURL in google auth config');	
+		throw new Error('Missing callbackURL in google auth config');
 	}
 
 	var strategy = new GoogleStrategy({

--- a/app/auth/auth-google-oauth2.js
+++ b/app/auth/auth-google-oauth2.js
@@ -1,0 +1,71 @@
+/*******************************************************************************
+* Copyright (C) 2012 eBay Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+******************************************************************************/
+
+module.exports = function(app, passport, config) {
+	var _ = require('underscore');
+	var url = require('url');
+	var GoogleStrategy = require('passport-google-oauth2');
+	var emails = config['auth-google'].emails;
+	var clientID = config['auth-google'].clientID;
+	var clientSecret = config['auth-google'].clientSecret;
+	var callbackURL = config['auth-google'].callbackURL;
+	var callbackPath = url.parse(callbackURL).path;
+
+	if (!emails || emails.length === 0) {
+		throw new Error('Missing allowed emails array in google auth config');
+	}
+
+	if(!clientSecret){
+		throw new Error('Missing clientSecret in google auth config');	
+	}
+
+	if(!callbackURL){
+		throw new Error('Missing callbackURL in google auth config');	
+	}
+
+	var strategy = new GoogleStrategy({
+	    clientID: clientID,
+	    clientSecret: clientSecret,
+	    callbackURL: callbackURL,
+	    scope: 'email'
+	},
+
+		function(accessToken, refreshToken, profile, done) {
+			var email = profile.emails[0].value;
+
+			if (_.indexOf(emails, email) === -1) {
+				done(null, false, { message: "User " + email + " does not have access rights to use Asimov Deploy" });
+				return;
+			}
+
+			done(null, {
+				name: profile.displayName,
+				email: email,
+				id: email
+			});
+		}
+	);
+
+
+	passport.use(strategy);
+
+	app.get(callbackPath,passport.authenticate('google', { successRedirect: '/', failureRedirect: '/', failureFlash: true }));
+
+	app.get('/auth/google', function(req, res, next) {
+		passport.authenticate('google')(req, res, next);
+	});
+
+};

--- a/app/auth/auth.js
+++ b/app/auth/auth.js
@@ -39,7 +39,17 @@ module.exports = function(app, config) {
 	}
 
 	if (config['auth-google']) {
-		require('./auth-google')(app, passport, config);
+		if(config['auth-google'].clientID){
+			require('./auth-google-oauth2')(app, passport, config);
+		} else {
+			console.warn('OpenID2 for Google accounts is going away on April 20, 2015');
+			console.warn(
+				'To continue using Google auth after that date, ' +
+				'go to https://console.developers.google.com to configure OAuth 2.0 credentials and enable the Google+ API, ' +
+				'then add ClientID, clientSecret and callbackURL to your asimov google-auth config.'
+			);
+			require('./auth-google')(app, passport, config);
+		}
 	}
 
 	if (config['auth-anonymous']) {

--- a/config.example.json
+++ b/config.example.json
@@ -16,6 +16,9 @@
 	},
 
 	"auth-google": {
-		"emails": [ "some_user_email_change_this@gmail.com" ]
+		"emails": [ "some_user_email_change_this@gmail.com" ],
+		"clientID": "clientID from https://console.developers.google.com",
+		"clientSecret": "clientSecret from https://console.developers.google.com",
+		"callbackURL": "callbackURL entered in https://console.developers.google.com, example http://your-host.com/auth/google/callback"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "grunt-contrib-cssmin": "~0.6.0",
     "grunt-contrib-watch": "~0.3.1",
     "grunt-contrib-jshint": "~0.4.3",
-    "grunt-mocha-test": "*",
+    "grunt-mocha-test": "~0.12.6",
     "grunt-cli": "~0.1.7",
     "grunt-notify": "~0.2.3",
-    "mocha": "1.6.0",
+    "mocha": "1.20.0",
     "should": "*",
     "sinon": "~1.7.3"
   },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "passport": "~0.1.17",
     "passport-local": "~0.1.6",
     "passport-google": "~0.3.0",
+    "passport-google-oauth2": "~0.1.4",
     "connect-flash": "~0.1.1"
   },
   "repository": {


### PR DESCRIPTION
 OpenID2 for Google accounts is going away on April 20, 2015, see https://support.google.com/accounts/answer/6135882?authuser=2

This commit adds an option to use OAuth2