### PR TITLE
Fixes grunt error after upgrade to Less 1.4.0

### DIFF
--- a/public/css/bootstrap/mixins.less
+++ b/public/css/bootstrap/mixins.less
@@ -558,13 +558,13 @@
   .core (@gridColumnWidth, @gridGutterWidth) {
 
     .spanX (@index) when (@index > 0) {
-      (~".span@{index}") { .span(@index); }
+      .span@{index} { .span(@index); }
       .spanX(@index - 1);
     }
     .spanX (0) {}
 
     .offsetX (@index) when (@index > 0) {
-      (~".offset@{index}") { .offset(@index); }
+      .offset@{index} { .offset(@index); }
       .offsetX(@index - 1);
     }
     .offsetX (0) {}
@@ -603,14 +603,14 @@
   .fluid (@fluidGridColumnWidth, @fluidGridGutterWidth) {
 
     .spanX (@index) when (@index > 0) {
-      (~".span@{index}") { .span(@index); }
+      .span@{index} { .span(@index); }
       .spanX(@index - 1);
     }
     .spanX (0) {}
 
     .offsetX (@index) when (@index > 0) {
-      (~'.offset@{index}') { .offset(@index); }
-      (~'.offset@{index}:first-child') { .offsetFirstChild(@index); }
+      .offset@{index} { .offset(@index); }
+      .offset@{index}:first-child { .offsetFirstChild(@index); }
       .offsetX(@index - 1);
     }
     .offsetX (0) {}
@@ -653,7 +653,7 @@
   .input(@gridColumnWidth, @gridGutterWidth) {
 
     .spanX (@index) when (@index > 0) {
-      (~"input.span@{index}, textarea.span@{index}, .uneditable-input.span@{index}") { .span(@index); }
+      input.span@{index}, textarea.span@{index}, .uneditable-input.span@{index} { .span(@index); }
       .spanX(@index - 1);
     }
     .spanX (0) {}


### PR DESCRIPTION
The upgrade to Less 1.4.0 breaks Bootstrap 2 due to a change in the Less syntax. The grunt Less task returns a parse error when the ~ operator is used in the mixins file. Changed the less syntax so that it works again.

There is an issue for this in the Less repo - https://github.com/less/less.js/issues/1365. We could solve this by upgrading Bootstrap but it is much easier to just fix the mixins file. Previous experiences upgrading Bootstrap have been painful. Or what do you think about this?

I have confirmed that the grunt task works again and that the generated css seems fine. It is the grid css that would be affected. For example, the last change in the mixins.less file generates the following css and it looks right:

```css
input.span12,
textarea.span12,
.uneditable-input.span12 {
  width: 926px;
}
```