### PR TITLE
Use node-localstorage version 5.0.0 due to bug with 5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "express": "3.1.1",
     "grunt": "0.4.1",
     "jade": "0.28.2",
-    "node-localstorage": "^0.5.0",
+    "node-localstorage": "0.5.0",
     "node-uuid": "^1.4.2",
     "passport": "~0.1.17",
     "passport-google": "~0.3.0",


### PR DESCRIPTION
Use the specific version 5.0.0 of node-localstorage due to bug with version 5.2.0. This solves a problem of the annotations solution which are using node-localstorage.