### PR TITLE
 Add configuration parameter for socket.io log level

### DIFF
--- a/app/start-server.js
+++ b/app/start-server.js
@@ -37,6 +37,10 @@ module.exports = function(app, http, config) {
 				io.set('heartbeat timeout', 30);
 				io.set('heartbeat interval', 35);
 				io.set("polling duration", 40);
+
+				if (config['socket-io'] && config['socket-io'].logLevel) {
+					io.set('log level', config['socket-io'].logLevel);
+				}
 			});
 		}
 

--- a/config.example.json
+++ b/config.example.json
@@ -31,5 +31,9 @@
         "autopilot": {
             "enabled" : true
         }
+    },
+
+    "socket-io": {
+    	"logLevel": 2
     }
 }


### PR DESCRIPTION
 socket.io per default uses log level 3 (debug). With this new configuration parameter
    you can modify the config.json without changing any code, see config.example.json as example.

Possible log levels:
    0 - errors
    1 - warnings
    2 - info
    3 - debug