### PR TITLE
fix: verify step spinner causes jumpiness in ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "grunt-notify": "~0.2.3",
     "mocha": "1.20.0",
     "should": "*",
-    "should-promised": "^0.3.1",
     "sinon": "~1.7.3"
   },
   "engines": {

--- a/public/css/deploy-unit-list.less
+++ b/public/css/deploy-unit-list.less
@@ -82,8 +82,12 @@
 	}
 }
 
+.unit-instance-verify-spinner {
+	display: inline-block;
+}
 
 .unit-instance-verify-glimps {
+	display: inline-block;
 
 	.verify-step {
 			display: inline-block;

--- a/public/templates/dashboard/unit-instance-view.handlebars
+++ b/public/templates/dashboard/unit-instance-view.handlebars
@@ -41,7 +41,7 @@
 </td>
 <td style="width: 100%; border-left: none">
 	{{#if showSpinner}}
-		<img src='/img/loading.gif' />
+		<img class="unit-instance-verify-spinner" src='/img/loading.gif' />
 	{{/if}}
 
 	{{#if verifySteps}}

--- a/test/backend/autopilot-specs.js
+++ b/test/backend/autopilot-specs.js
@@ -1,5 +1,4 @@
 require('should');
-require('should-promised');
 
 describe('Autopilot', function() {
 	describe('when requesting deployable unit sets', function() {


### PR DESCRIPTION
Problem:
The spinner that appears during the progress of the verify steps is
positioned above the progress bar wich causes the height of each row to
grow/shrink when the spinner appears/disappears.

Solution:
Make both spinner and progress bar inline-block elements to position
them next to each other.

![image](https://cloud.githubusercontent.com/assets/452261/12132163/52f738d2-b419-11e5-822d-990cb494c3ae.png)
