### PR TITLE
fix: undefined unit list breaks js in client

### DIFF
--- a/app/services/agent-api-client.js
+++ b/app/services/agent-api-client.js
@@ -51,7 +51,7 @@ var AgentApiClient = function(config, restify) {
 			}
 
 			this.get(agent.name, '/units/list', function(units) {
-				result.push({agent: agent, units: units});
+				result.push({agent: agent, units: units || []});
 				done();
 			});
 

--- a/test/backend/agent-api-client-specs.js
+++ b/test/backend/agent-api-client-specs.js
@@ -62,7 +62,7 @@ describe('AgentApiClient', function(){
 
 			var restify = {
 				createJsonClient: function() {
-					return { 
+					return {
 						get: function(url, cb) {
 							cb();
 						}

--- a/test/backend/agent-api-client-specs.js
+++ b/test/backend/agent-api-client-specs.js
@@ -46,4 +46,46 @@ describe('AgentApiClient', function(){
 
 	});
 
+	describe('when agent has empty unit list', function() {
+		var unitListForAgentGroup = [];
+		var fakeAgent = { group: "groupName" };
+
+		before(function() {
+			var fakeConfig = {
+				agents: [
+					fakeAgent
+				],
+				getAgent: function() {
+					return { url: 'agentUrl', apiKey: '12321313213' };
+				}
+			};
+
+			var restify = {
+				createJsonClient: function() {
+					return { 
+						get: function(url, cb) {
+							cb();
+						}
+					};
+				}
+			};
+
+			var apiClient = require("../../app/services/agent-api-client").create(fakeConfig, restify);
+
+			apiClient.getUnitListForAgentGroup("groupName", function(results) {
+				unitListForAgentGroup = results;
+			});
+		});
+
+		it('should return empty array (instead of undefined)', function() {
+			unitListForAgentGroup.should.deepEqual([
+				{
+					agent: fakeAgent,
+					units: []
+				}
+			]);
+		});
+
+	});
+
 });


### PR DESCRIPTION
Problem:
If an agent has an empty list of units it will be undefined when we GET
list of units for an agent group. This will cause a js error when we try
to forEach the undefined array (unit-collectinon.js row 86).

As a result the list of deployable units will not be updated in the UI when
the user chooses such a group in the top right corner of the dashboard.

Solution:
Assign an empty array to the units property if agent has no units.