### PR TITLE
fix: Always enable configuration of Socket.io logging level

### DIFF
--- a/app/start-server.js
+++ b/app/start-server.js
@@ -29,6 +29,9 @@ module.exports = function(app, http, config) {
 	server.on("listening", function() {
 
 		io = io.listen(server);
+		if (config['socket-io'] && config['socket-io'].logLevel !== undefined) {
+			io.set('log level', config['socket-io'].logLevel);
+		}
 
 		if (config['enable-demo']) {
 			io.configure(function () {
@@ -37,10 +40,6 @@ module.exports = function(app, http, config) {
 				io.set('heartbeat timeout', 30);
 				io.set('heartbeat interval', 35);
 				io.set("polling duration", 40);
-
-				if (config['socket-io'] && config['socket-io'].logLevel) {
-					io.set('log level', config['socket-io'].logLevel);
-				}
 			});
 		}
 


### PR DESCRIPTION
Previously, it was only possible to configure logging when demo mode was
enabled