### PR TITLE
fix: Request profile info and email for google oath2

### DIFF
--- a/app/auth/auth-google-oauth2.js
+++ b/app/auth/auth-google-oauth2.js
@@ -40,7 +40,7 @@ module.exports = function(app, passport, config) {
 	    clientID: clientID,
 	    clientSecret: clientSecret,
 	    callbackURL: callbackURL,
-	    scope: 'email'
+	    scope: ['https://www.googleapis.com/auth/userinfo.profile', 'https://www.googleapis.com/auth/userinfo.email']
 	},
 
 		function(accessToken, refreshToken, profile, done) {


### PR DESCRIPTION
Previously, we only requested email, which caused some users to have a null name. This commit attempts to fix that