### PR TITLE
Enable installation on modern node- and npm-versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "passport-local": "~0.1.6",
     "restify": "2.3.5",
     "socket.io": "0.9.16",
+    "socket.io-client": "0.9.16",
     "underscore": "1.4.4",
     "when": "^3.7.3"
   },
@@ -44,8 +45,8 @@
     "sinon": "~1.7.3"
   },
   "engines": {
-    "node": "0.10.x",
-    "npm": "1.2.x"
+    "node": "5.4.x",
+    "npm": "3.3.x"
   },
   "bin": {
     "asimov-deploy-ui-init": "bin/init"

--- a/public/app/config.js
+++ b/public/app/config.js
@@ -32,7 +32,7 @@ require.config({
 		"backbone.wreqr": "../libs/backbone.wreqr",
 		"jquery.cookie": "../libs/jquery.cookie",
 
-		'socket.io': '../../node_modules/socket.io/node_modules/socket.io-client/dist/socket.io'
+		'socket.io': '../../node_modules/socket.io-client/dist/socket.io'
 	},
 
 	packages: [


### PR DESCRIPTION
This change allows installation on modern npm versions that flatten the node_modules tree.