### PR TITLE
Display agent list grouped by agent

### DIFF
--- a/app/agents.js
+++ b/app/agents.js
@@ -34,7 +34,7 @@ module.exports = function(app, config) {
 			});
 		});
 
-		agentsResp = _.sortBy(agentsResp);
+		agentsResp = _.sortBy(agentsResp, 'name');
 		res.json(agentsResp);
 	});
 

--- a/app/demo-mode/demo-data-generator.js
+++ b/app/demo-mode/demo-data-generator.js
@@ -20,18 +20,18 @@ var units = [];
 var versions = {};
 
 for(var i = 1; i <= 5; i++) {
-	agents.push({
-		name: "SE1-WEBFRONT-0" + i,
+    agents.push({
+        name: "SE1-WEBFRONT-0" + i,
         group: 'Web servers',
-		dead: false,
-		version: "0.6.12",
-		configVersion: 43,
-		loadBalancerState: {
-			enabled: true,
-			connectionCount: Math.floor((Math.random()*580)),
-			serverId: "SE1-WEBFRONT-0" + i
-		}
-	});
+        dead: false,
+        version: "0.6.12",
+        configVersion: 43,
+        loadBalancerState: {
+            enabled: true,
+            connectionCount: Math.floor((Math.random()*580)),
+            serverId: "SE1-WEBFRONT-0" + i
+        }
+    });
 }
 
 for(var i = 1; i <= 3; i++) {

--- a/app/demo-mode/demo-mode.js
+++ b/app/demo-mode/demo-mode.js
@@ -41,7 +41,7 @@ module.exports = function(app, config) {
 	}
 
 	app.get('/agents/list', app.ensureLoggedIn, function(req, res) {
-		res.json(demodata.agents);
+		res.json(_.sortBy(demodata.agents, 'name'));
 	});
 
 	app.get('/units/list', app.ensureLoggedIn, function(req, res) {

--- a/public/app/agentlist.js
+++ b/public/app/agentlist.js
@@ -16,11 +16,12 @@
 
 define([
 	"jquery",
+	"underscore",
 	"backbone",
 	"marionette",
 	"app"
 ],
-function($, Backbone, Marionette, app) {
+function($, _, Backbone, Marionette, app) {
 
 	var AgentItemView = Marionette.ItemView.extend({
 		template: "agent-item-view",
@@ -34,7 +35,33 @@ function($, Backbone, Marionette, app) {
 	});
 
 	var AgentCollection = Backbone.Collection.extend({
-		url: "/agents/list"
+		url: "/agents/list",
+
+		parse: function (agentList) {
+			var agentGroups = _.groupBy(agentList, 'name');
+
+			var data = _.map(agentGroups, function(group){
+				var sortedGroups = _.sortBy(_.pluck(group, 'group'));
+				var groupString = _.reduce(sortedGroups, function (memo, val) {
+					if (memo) {
+						return memo + ', ' + val;
+					}
+
+					return val;
+				}, null);
+
+				return {
+					name: group[0].name,
+					groups: groupString,
+					dead: group[0].dead,
+					version: group[0].version,
+					configVersion: group[0].configVersion,
+					loadBalancerState: group[0].loadBalancerState
+				};
+			});
+
+			return data;
+		}
 	});
 
 	var agentsList = new AgentCollection();

--- a/public/templates/agent-item-view.handlebars
+++ b/public/templates/agent-item-view.handlebars
@@ -1,5 +1,5 @@
 <td>{{name}}</td>
-<td>{{group}}</td>
+<td>{{groups}}</td>
 <td>{{version}}</td>
 <td>{{configVersion}}</td>
 <td>

--- a/public/templates/agent-list-view.handlebars
+++ b/public/templates/agent-list-view.handlebars
@@ -16,7 +16,7 @@
         <thead>
             <tr>
                 <th style="width: 150px;">Name</th>
-                <th style="width: 150px;">Group</th>
+                <th style="width: 300px;">Groups</th>
                 <th style="width: 80px;">Version</th>
                 <th style="width: 120px;">Config Version</th>
                 <th>Status</th>


### PR DESCRIPTION
The page agents now displays the agent list grouped by agent and it's groups as a concatenated string. Easier to read if you have an agent in multiple groups