### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/app/deploy-lifecycle.js
+++ b/app/deploy-lifecycle.js
@@ -19,7 +19,7 @@ module.exports = function(app, config) {
 	var lifecycleClient = require('./services/deploy-lifecycle-client').create(config);
 	var lifecycleSession = require('./services/deploy-lifecycle-session').create();
 	var featureToggle = require('./feature-toggle').create(config);
-	var uuid = require('node-uuid');
+	var uuid = require('uuid');
 
 	var annotationsConfig = featureToggle.getActiveFeature('deployAnnotations');
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "grunt": "0.4.1",
     "jade": "0.28.2",
     "node-localstorage": "0.5.0",
-    "node-uuid": "^1.4.2",
     "passport": "~0.1.17",
     "passport-google": "~0.3.0",
     "passport-google-oauth2": "~0.1.4",
@@ -21,6 +20,7 @@
     "socket.io": "0.9.16",
     "socket.io-client": "0.9.16",
     "underscore": "1.4.4",
+    "uuid": "^3.0.0",
     "when": "^3.7.3"
   },
   "repository": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.