### PR TITLE
Forward deploy logs from agents to node front

### DIFF
--- a/app/services/agent-api-client.js
+++ b/app/services/agent-api-client.js
@@ -27,7 +27,7 @@ var AgentApiClient = function(config, restify) {
 		client.get(url, function(err, req, _, data) {
 			if (err) {
 				agent.dead = true;
-				console.log("Error in trying to query agent");
+				console.log("Error in trying to query agent",err);
 			}
 			dataCallback(data);
 		});
@@ -137,6 +137,23 @@ var AgentApiClient = function(config, restify) {
 	this.getAgentUnitStatuses = function (agentName, dataCallback) {
 		this.get(agentName, '/unit-statuses', dataCallback);
 	};
+
+	this.getDeployLog = function(agentName, unitName, position, dataCallback){
+		var agent =  config.getAgent(agentName);
+		if(agent == null ){
+			console.error("Attempt to get log from unknown agent",agentName);
+			dataCallback(null);
+			return;
+		}
+		var client = restify.createStringClient({ url: agent.url, connectTimeout: 200 });
+		var url = '/deploylog/file/' + unitName + '/' + position;
+		client.get(url, function(err, req, _, data) {
+			if (err) {
+				console.log("Error in trying to query agent",err);
+			}
+			dataCallback(data);
+		});
+	} 
 
 	this.test = function(agentName) {
 		return config.getAgent(agentName);

--- a/app/versions.js
+++ b/app/versions.js
@@ -1,30 +1,40 @@
 /*******************************************************************************
-* Copyright (C) 2012 eBay Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-******************************************************************************/
+ * Copyright (C) 2012 eBay Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
 
 var querystring = require("querystring");
 
-module.exports = function(app, config) {
+module.exports = function (app, config) {
+    var agentApiClient = require('./services/agent-api-client').create(config);
 
-	app.get('/deploylog/file', app.ensureLoggedIn, function(req, res) {
+    app.get('/deploylog/file', app.ensureLoggedIn, function (req, res) {
 
-		var agent =  config.getAgent(req.query.agentName);
-		var unitName = querystring.escape(req.query.unitName);
+        var agent = config.getAgent(req.query.agentName);
+        var unitName = querystring.escape(req.query.unitName);
 
-		res.redirect(agent.url + '/deploylog/file/' + unitName + "/" + req.query.position);
-
-	});
+        agentApiClient.getDeployLog(
+            req.query.agentName,
+            req.query.unitName,
+            req.query.position,
+            function (data) {
+                if(data == null){
+                    res.status(404).end();
+                    return;
+                }
+                res.type('text').send(data);
+            })
+    });
 
 };


### PR DESCRIPTION
Previously, the deploy logs were served directly from the agents
This commit changes that so that the deploy logs are served from the nodefront instead