### PR TITLE
Don't crash deployCompleted when session is null

### DIFF
--- a/app/agents.js
+++ b/app/agents.js
@@ -132,9 +132,9 @@ module.exports = function (app, config) {
 			correlationId: correlationId,
 			eventName: body.eventName,
 			agentName: body.agentName,
-			user: session.user,
-			title: session.data.title,
-			description: session.data.bodyc
+			user: session ? session.user : body.userName,
+			title: session ? session.data.title : '',
+			description: session ? session.data.body : ''
 		};
 		stackDriverLogger.log(logObj);
 		// console.log('Asimov Deploy unitName:' + body.unitName + ' ' + logObj);


### PR DESCRIPTION
The nodefront used to fail in deployCompleted when there was no deploy sessions. This is a fix for that