### PR TITLE
Handle unknown agent in shutdown

### DIFF
--- a/app/agents.js
+++ b/app/agents.js
@@ -114,7 +114,9 @@ module.exports = function (app, config) {
 	app.post("/agent/shutdown", function (req, res) {
 		var agent = config.getAgent(req.body.name);
 		if (!agent) {
+			console.log(`Attempt to shutdown unknown agent ${req.body.name}. Available agents: ${config.agents.map(a=>a.name)}`);
 			res.json('ok');
+			return;
 		}
 		agent.dead = true;
 


### PR DESCRIPTION
Calling shutdown with an unknown agent previously crashed with the following error:
TypeError: Cannot set property 'dead' of undefined

    at /asimov-deploy/app/agents.js:119:14

    at Layer.handle [as handle_request] (/asimov-deploy/node_modules/express/lib/router/layer.js:95:5)

    at next (/asimov-deploy/node_modules/express/lib/router/route.js:137:13)

    at Route.dispatch (/asimov-deploy/node_modules/express/lib/router/route.js:112:3)

    at Layer.handle [as handle_request] (/asimov-deploy/node_modules/express/lib/router/layer.js:95:5)

    at /asimov-deploy/node_modules/express/lib/router/index.js:281:22

    at Function.process_params (/asimov-deploy/node_modules/express/lib/router/index.js:335:12)

    at next (/asimov-deploy/node_modules/express/lib/router/index.js:275:10)

    at Layer.handle [as handle_request] (/asimov-deploy/node_modules/express/lib/router/layer.js:91:12)

    at trim_prefix (/asimov-deploy/node_modules/express/lib/router/index.js:317:13)

This commit fixes that and logs the unknown agent instead